### PR TITLE
Only publish required files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.4",
   "description": "Nordic Thingy:52 Node.js library example. Please see http://www.nordicsemi.com/thingy for the latest Nordic Thingy:52 news and software releases.",
   "main": "index.js",
+  "files": [
+    "index.js", 
+    "lib"
+  ],
   "directories": {
     "example": "examples"
   },


### PR DESCRIPTION
added a "files" section to package.json to avoid publishing the `examples` directory to NPM